### PR TITLE
Make purple events fire again

### DIFF
--- a/Source/VEE/Others/IncidentWorker_MakeGameCondition.cs
+++ b/Source/VEE/Others/IncidentWorker_MakeGameCondition.cs
@@ -11,7 +11,6 @@ namespace VEE
             if (Find.World.GetComponent<WorldComp_Purple>() is WorldComp_Purple comp)
             {
                 bool enoughDaysPassed = comp.tickLastPurpleEvent == 0 || Find.TickManager.TicksGame - comp.tickLastPurpleEvent > 60000 * Settings.VEEMod.settings.daysBetweenPurpleEvent;
-                comp.tickLastPurpleEvent = Find.TickManager.TicksGame;
                 return base.CanFireNowSub(parms) && enoughDaysPassed;
             }
             return false;
@@ -25,6 +24,9 @@ namespace VEE
             conditionManager.RegisterCondition(gameCondition);
             parms.letterHyperlinkThingDefs = gameCondition.def.letterHyperlinks;
             SendStandardLetter(def.letterLabel, def.letterText, def.letterDef, parms, LookTargets.Invalid);
+
+            Find.World.GetComponent<WorldComp_Purple>().tickLastPurpleEvent = Find.TickManager.TicksGame;
+
             return true;
         }
     }


### PR DESCRIPTION
6da78ec2d930c8612cf4fe302a469c0ddf358bb5 made the cooldown interval between purple events configurable in mod settings, but it ended up making purple events almost never fire, because it sets `tickLastPurpleEvent` in `CanFireNowSub()`, which is called not just when an incident is about to fire, but also when the storyteller is generating a list of potential incidents to fire. Fix it by setting `tickLastPurpleEvent` in `TryExecuteWorker` instead, which is when the event actually fires.