### PR TITLE
Refactor drought-related checks and improve null safety in HarmonyInit

### DIFF
--- a/1.6/Source/VEE/VEE.csproj
+++ b/1.6/Source/VEE/VEE.csproj
@@ -87,6 +87,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="Mscorlib" />
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
I was having this error and it looked like this solution would fix it.
```
Error in PostMapInit() for Plant_Potato579536: System.NullReferenceException: Object reference not set to an instance of an object
[Ref 66A362E5]
at VEE.Plant_PostMapInit_Patch.Postfix (RimWorld.Plant& __instance, System.Int32& ___madeLeaflessTick) [0x0000f] in <5f9e5b3f68a74d34a61d038b40611c7d>:0
at RimWorld.Plant.PostMapInit () [0x0000b] in <46372f5dadbf4af8939e608076251180>:0
- POSTFIX Kikohi.VanillaEventExpanded: Void VEE.Plant_PostMapInit_Patch:Postfix(Plant& __instance, Int32& ___madeLeaflessTick)
at Verse.Map.FinalizeInit () [0x000ac] in <46372f5dadbf4af8939e608076251180>:0
- PREFIX com.harmony.rimworld.nanamedoors: Void NanameDoors.Patch_Map_FinalizeInit:Prefix(Map __instance)
- POSTFIX UnlimitedHugs.HugsLib: Void HugsLib.Patches.Map_FinalizeInit_Patch:MapLoadedHook(Map __instance)
- POSTFIX SmashPhil.VehicleFramework: Void Vehicles.Patch_Areas:BackfillVehicleAreas(Map __instance)
- POSTFIX PerformanceOptimizer.Main: Void PerformanceOptimizer.Map_FinalizeInit:Postfix()
- POSTFIX Owlchemist.SimpleFX.Splashes: Void SimpleFxSplashes.Patch_Map_FinalizeInit:Postfix(Map __instance)
- POSTFIX Harmony_PrisonLabor: Void PrisonLabor.HarmonyPatches.Triggers+Patch_ShowNews:Postfix()
- POSTFIX GiddyUp: Void GiddyUp.Patch_MapFinalizeInit:Postfix(Map __instance)
``` 
I tried not to refactor too much.

On the other hand, I don't know how it was working for you, because for me it required me to include a reference to `Mscorlib` in order to use `Scribe_Collections` in many other files when trying to compile them. The output from the Rider IDE shows:
```
0>LordJob_HuntingParty.cs(27,13): Error CS7069 : La referencia al tipo 'Stack<>' confirma que está definida en 'mscorlib', pero no se encontró
0>LordJob_HuntingParty.cs(27,13): Error CS7069 : La referencia al tipo 'Queue<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PlanetEvent.cs(41,13): Error CS7069 : La referencia al tipo 'Stack<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PlanetEvent.cs(41,13): Error CS7069 : La referencia al tipo 'Queue<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PlanetEvent.cs(42,13): Error CS7069 : La referencia al tipo 'Stack<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PlanetEvent.cs(42,13): Error CS7069 : La referencia al tipo 'Queue<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PsychicBloom.cs(91,13): Error CS7069 : La referencia al tipo 'Stack<>' confirma que está definida en 'mscorlib', pero no se encontró
0>PsychicBloom.cs(91,13): Error CS7069 : La referencia al tipo 'Queue<>' confirma que está definida en 'mscorlib', pero no se encontró
```